### PR TITLE
continue_build_formalization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             git clone https://github.com/tfutils/tfenv.git ~/.tfenv
             export PATH="$HOME/.tfenv/bin:$PATH"
             export TF_CURL_OUTPUT=1
-            [[ $(ls -a | grep .tf | grep -w "required_version" *.tf | wc -l) -ge 1 ]]
+            if [[ $(ls -a | grep .tf | grep -w "required_version" *.tf | wc -l) -ge 1 ]]; then
               echo "Found required_version declaration, using min-required"
               tfenv install min-required
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             git clone https://github.com/tfutils/tfenv.git ~/.tfenv
             export PATH="$HOME/.tfenv/bin:$PATH"
             export TF_CURL_OUTPUT=1
-            if ls -a | grep .tf | grep -w "required_version" *.tf; then
+            [[ $(ls -a | grep .tf | grep -w "required_version" *.tf | wc -l) -ge 1 ]]
               echo "Found required_version declaration, using min-required"
               tfenv install min-required
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,10 @@ jobs:
           name: pre-commit_run
           command: |
              export PATH="$HOME/.tfenv/bin:$PATH"
+             export TF_LOG=INFO
              tfenv use
              terraform version
+             terraform init
              pre-commit run --all-files
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@ jobs:
   run_pre-commit-terraform_hooks:
     docker:
       - image: 'circleci/golang:latest'
+    environment:
+      AWS_DEFAULT_REGION: us-west-2
     steps:
       - checkout
       - aws-cli/install
@@ -46,7 +48,7 @@ jobs:
           name: pre-commit_run
           command: |
              export PATH="$HOME/.tfenv/bin:$PATH"
-             export TF_LOG=INFO
+             export TF_LOG=TRACE
              tfenv use
              terraform version
              terraform init

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,6 @@
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
-#    - id: terraform_validate
+    - id: terraform_validate
     - id: terraform_tflint
     - id: terraform_tfsec

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Repo serves to various terraform toolsets.
 
 | Name | Version |
 |------|---------|
-| terraform | <= 0.12.24, >= 0.12 |
+| terraform | ~> 0.12.24, >= 0.12 |
 | aws | ~> 2.62 |
 
 ## Providers

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "<= 0.12.24, >= 0.12"
+  required_version = "~> 0.12.24, >= 0.12"
   required_providers {
     aws = "~> 2.62"
   }


### PR DESCRIPTION
Fix weird required_version constraint blocking newer tf version runs. CircleCI build now runs through init and validate steps. Defaults to aws region: us-west-2. 